### PR TITLE
20576: Adjusts workflows to use centralized NPM test/publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,76 +25,15 @@ jobs:
       optional-release-tag: ${{ inputs.optional-release-tag }}
 
   npm-test:
-    # Regression testing
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        env:
-          NPM_TOKEN: ${{ secrets.JFROG_ACCESS_TOKEN }}
-        run: |
-          echo -e "\n//dpbuild.jfrog.io/:_authToken=${NPM_TOKEN}" >> .npmrc
-          npm ci
-
-      - name: Test
-        run: npm run test
+    uses: howsoai/.github/.github/workflows/npm-test.yml@main
+    secrets: inherit
 
   release:
     needs:
       - metadata
       - npm-test
     if: inputs.build-type == 'release'
-    environment:
-      name: Artifactory
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.JFROG_ACCESS_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "21.x"
-          registry-url: ${{ secrets.JFROG_URL }}/artifactory/npm-remote
-
-      - name: Set package version
-        run: |
-          sed -i "s|\"version\": \"0.0.0\"|\"version\": \"${{ needs.metadata.outputs.version }}\"|g" ./package.json
-
-      - name: Install dependencies
-        env:
-          NPM_TOKEN: ${{ secrets.JFROG_ACCESS_TOKEN }}
-        run: |
-          echo -e "\n//dpbuild.jfrog.io/:_authToken=${NPM_TOKEN}" >> .npmrc
-          npm ci
-
-      - name: Build package
-        run: |
-          npm run build
-          # Remove .npmrc so that we can easily change registries to npm-edge (for publishing)
-          rm -f .npmrc
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "21.x"
-          registry-url: ${{ secrets.JFROG_URL }}/artifactory/api/npm/npm-edge/
-
-      - name: Publish Node package
-        run: |
-          npm publish
-
-      - name: Create Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.metadata.outputs.version }}
-          commit: ${{ github.sha }}
-          name: "${{ github.event.repository.name }} ${{ needs.metadata.outputs.version }}"
-          artifactErrorsFailBuild: true
-          generateReleaseNotes: true
-          makeLatest: legacy
+    uses: howsoai/.github/.github/workflows/npm-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{ needs.metadata.outputs.version }}


### PR DESCRIPTION
NPM test and publish CI/CD jobs will now use the reusable, centralized versions found in the `.github` repository. This is consistent with other Howso projects.